### PR TITLE
update the register page link of OSGi event

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,11 +68,11 @@ The language of this event is Chinese. It will be hold in Huawei Shenzhen Base J
 <img src="https://www.osgi.org/wp-content/uploads/OSGi-Header-Logo-e1463514096111.jpg">
 <p>Topics | 主题</p>
 <ul>
-    <li>19.00hrs minutes - Welcome & Intro - Kai Hackbath (Bosch & OSGi Alliance Board Member)</li>
-    <li>19.10hrs - China OSGi Users’ Forum - Jeff Liu (Richstone Data Technologies)</li>    
-    <li>19.20hrs - OSGi and IoT - Seven (Huawei)</li>
-    <li>20.00hrs - OSGi tooling - experiences from implementing OSGi based solutions at Liferay - Terry Jia (Liferay)</li>
-    <li>20.40hrs - To Be Confirmed (Bosch)</li>
+    <li>19.00hrs minutes - Welcome & Intro/开场介绍 - Kai Hackbath (Bosch & OSGi Alliance Board Member)</li>
+    <li>19.10hrs - China OSGi Users’ Forum/中国OSGi用户论坛 - Jeff Liu (Richstone Data Technologies)</li>    
+    <li>19.20hrs - OSGi and IoT/OSGi和物联网 - Seven (Huawei)</li>
+    <li>20.00hrs - OSGi tooling/OSGi工具 - experiences from implementing OSGi based solutions at Liferay - Terry Jia (Liferay)</li>
+    <li>20.40hrs - To Be Confirmed/待确定 (Bosch)</li>
 </ul>
 <p>Huawei <img src="http://www.huawei.com/minisite/error/404-en_files/logo_new.png" width="100" height="25"> 华为 provides some soft drinks and tea.</p> 
 <p>OSGi alliance <img src="https://www.osgi.org/wp-content/uploads/OSGi-Header-Logo-e1463514096111.jpg" width="100" height="37"> OSGi联盟 provides some fast food.</p> 

--- a/index.html
+++ b/index.html
@@ -64,16 +64,15 @@ TBD. Planned meeting date is 2017-7-20.
 TBD
 
 <h3><a id="OSGi2017" href="#OSGi2017">OSGi Developer Outreach Event, March 28th 2017, 7pm</a></h3>
-The meeting will be hold in Huawei Shenzhen Base J Unit Training Center, from 19:00 to 21:30 on March 28th(<a href="https://www.google.com/maps/place/Huawei+Shenzhen+Base+J+Unit+Training+Center/@22.6520922,114.0614901,17z/data=!4m8!1m2!2m1!1sHuawei+training+center+Shenzhen!3m4!1s0x0:0x78d5d5e00c78e84d!8m2!3d22.6513939!4d114.0628307?hl=en">Google map</a>, <a href="http://map.baidu.com/?shareurl=1&poiShareUid=669431e72e02e4466140a91c">Baidu map</a>).
+The language of this event is Chinese. It will be hold in Huawei Shenzhen Base J Unit Training Center, from 19:00 to 21:30 on March 28th(<a href="https://www.google.com/maps/place/Huawei+Shenzhen+Base+J+Unit+Training+Center/@22.6520922,114.0614901,17z/data=!4m8!1m2!2m1!1sHuawei+training+center+Shenzhen!3m4!1s0x0:0x78d5d5e00c78e84d!8m2!3d22.6513939!4d114.0628307?hl=en">Google map</a>, <a href="http://map.baidu.com/?shareurl=1&poiShareUid=669431e72e02e4466140a91c">Baidu map</a>).
 <img src="https://www.osgi.org/wp-content/uploads/OSGi-Header-Logo-e1463514096111.jpg">
 <p>Topics | 主题</p>
 <ul>
-    <li>19.00hrs minutes - Welcome & Intro - Kai (Bosch & OSGi Alliance Board Member) with Chinese translator (10 mins)</li>
-    <li>19.10hrs - China OSGi Users’ Forum - Intro, objectives and how to get involved - Jeff Liu (10 mins)</li>    
-    <li>19.20hrs - OSGi and IoT - Seven- Huawei (40 mins inc Q&A)</li>
-    <li>20.00hrs - OSGi tooling - experience from implementing OSGi based solutions at Liferay - Terry Jia - Liferay (40 mins inc Q&A)</li>
-    <li>20.40hrs - Bosch - TBC (40 mins inc Q&A)</li>
-    <li>21.30hrs - Close</li>
+    <li>19.00hrs minutes - Welcome & Intro - Kai Hackbath (Bosch & OSGi Alliance Board Member)</li>
+    <li>19.10hrs - China OSGi Users’ Forum - Jeff Liu (Richstone Data Technologies)</li>    
+    <li>19.20hrs - OSGi and IoT - Seven (Huawei)</li>
+    <li>20.00hrs - OSGi tooling - experiences from implementing OSGi based solutions at Liferay - Terry Jia (Liferay)</li>
+    <li>20.40hrs - To Be Confirmed (Bosch)</li>
 </ul>
 <p>Huawei <img src="http://www.huawei.com/minisite/error/404-en_files/logo_new.png" width="100" height="25"> 华为 provides some soft drinks and tea.</p> 
 <p>OSGi alliance <img src="https://www.osgi.org/wp-content/uploads/OSGi-Header-Logo-e1463514096111.jpg" width="100" height="37"> OSGi联盟 provides some fast food.</p> 

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ The meeting will be hold in Huawei Shenzhen Base J Unit Training Center, from 19
 <p>Huawei <img src="http://www.huawei.com/minisite/error/404-en_files/logo_new.png" width="100" height="25"> 华为 provides some soft drinks and tea.</p> 
 <p>OSGi alliance <img src="https://www.osgi.org/wp-content/uploads/OSGi-Header-Logo-e1463514096111.jpg" width="100" height="37"> OSGi联盟 provides some fast food.</p> 
 <p>This meeting is free, but the identity of participants need to be checked at the front door. Please register first.</p>
-<p>Register at <a href="https://yoopay.cn/event/83210600">https://yoopay.cn/event/83210600</a></p>
+<p>Register at <a href="https://yoopay.cn/event/osgidevevent2017">https://yoopay.cn/event/osgidevevent2017</a></p>
 <!--  
 below or 
 <script type="text/javascript" src="https://yoopay.cn/scripts/easyXDM.min.js"></script> <script type="text/javascript"> var REMOTE = "https://yoopay.cn";var transport = new easyXDM.Socket(/** The configuration */{remote: REMOTE + "/proxy.html?url=/payment/payment_widget/83210600%3Fwidth%3Dsmall%26attendeeList%3Dhideen%26ref%3D", swf: REMOTE + "/scripts/easyxdm.swf", container: "embedded", onMessage: function(message, origin) {this.container.getElementsByTagName("iframe")[0].style.width = "100%";this.container.getElementsByTagName("iframe")[0].style.height = parseInt(message) + 20 + "px";}});</script> <div id="embedded"></div>


### PR DESCRIPTION
The total ticket number of the OSGi event is only one, that's why you can't register...I modified it but the link need to be updated at the same time.